### PR TITLE
Fix Rock Paper Scissors card tone to match other game cards

### DIFF
--- a/client/src/components/Home.js
+++ b/client/src/components/Home.js
@@ -19,7 +19,7 @@ const games = [
     label: 'Reaction Duel',
     token: 'RPS',
     description: 'A timeless duel where every prediction can flip the match.',
-    tone: 'sunset',
+    tone: 'cobalt',
   },
 
   {


### PR DESCRIPTION
## Description
This PR fixes the styling inconsistency of the Rock-Paper-Scissors card on the homepage.

Previously, the card used a different `tone` value which made it look different from other game cards.  
I updated the tone so that the Rock-Paper-Scissors card now matches the styling of the other cards.

## Changes Made
- Updated the `tone` property for Rock-Paper-Scissors in `client/src/components/Home.js`
- Ensured the card styling is consistent with other game cards

## Issue Fixed
Fixes #51